### PR TITLE
Fix whitespace issues in README for GitHub rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ pod 'NMessenger', '1.0.76'
 ```
 
 ## Notes
-###For iOS 10 Support
+### For iOS 10 Support
 Add `NSPhotoLibraryUsageDescription` and `NSCameraUsageDescription` to your App Info.plist to specify the reason for accessing photo library and camera. See [Cocoa Keys](https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html) for more details.
 
-###Landscape Mode
+### Landscape Mode
 - **Landscape mode is not currently supported.** While it may be supported in a future release, we have disabled device rotation for `NMessengerViewController` to prevent issues.
 
 ## Getting Started


### PR DESCRIPTION
This is a tiny tiny thing, but noticed the lack of whitespace after the subheader `###`s was causing GH to not render them properly :)